### PR TITLE
Avoid error when an input contains non-ASCII (1-byte) characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ fn process_word(word: &str) -> Cow<'_, str> {
     if SMALL_RE.is_match(&lower_word) {
         Cow::from(lower_word)
     } else if starts_with_bracket(word) {
-        let rest = titlecase(&word[1..]);
+        let rest = titlecase(&word.chars().skip(1).collect::<String>());
         Cow::from(format!("({}", rest))
     } else if has_internal_slashes(word) {
         Cow::from(word.split('/').map(titlecase).join_with('/').to_string())
@@ -157,7 +157,7 @@ fn has_internal_caps(word: &str) -> bool {
 }
 
 fn has_internal_slashes(word: &str) -> bool {
-    !word.is_empty() && word[1..].contains('/')
+    !word.is_empty() && word.chars().skip(1).collect::<String>().contains('/')
 }
 
 fn starts_with_bracket(word: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ fn has_internal_caps(word: &str) -> bool {
 }
 
 fn has_internal_slashes(word: &str) -> bool {
-    !word.is_empty() && word.chars().skip(1).collect::<String>().contains('/')
+    !word.is_empty() && word.chars().skip(1).any(|chr| chr == '/')
 }
 
 fn starts_with_bracket(word: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ fn process_word(word: &str) -> Cow<'_, str> {
     if SMALL_RE.is_match(&lower_word) {
         Cow::from(lower_word)
     } else if starts_with_bracket(word) {
-        let rest = titlecase(&word.chars().skip(1).collect::<String>());
+        let rest = titlecase(&word[1..]);
         Cow::from(format!("({}", rest))
     } else if has_internal_slashes(word) {
         Cow::from(word.split('/').map(titlecase).join_with('/').to_string())
@@ -415,5 +415,11 @@ mod tests {
         lower_small_words,
         "Way Of The Dragon makes Of In An A lowercase",
         "Way of the Dragon Makes of in an a Lowercase"
+    );
+
+    testcase!(
+        small_greek_letters,
+        "μ",
+        "Μ"
     );
 }


### PR DESCRIPTION
When an input contains non-ASCII (1-byte) characters, slicing &str by 1 violates the character boundaries and causes panic.