### PR TITLE
Track MSRV in Cargo.toml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
     cpu: 8
   matrix:
     - environment:
-        RUST_VERSION: "1.40.0"
+        RUST_VERSION: "1.70.0"
     - environment:
         RUST_VERSION: "stable"
   environment:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "titlecase"
 description = "A tool and library that capitalizes text according to a style defined by John Gruber for post titles on his website Daring Fireball."
 version = "2.2.1"
-edition = "2018"
+edition = "2021"
 authors = ["Wesley Moore <wes@wezm.net>"]
 rust-version = "1.70.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "A tool and library that capitalizes text according to a style def
 version = "2.2.1"
 edition = "2018"
 authors = ["Wesley Moore <wes@wezm.net>"]
+rust-version = "1.70.0"
 
 documentation = "https://docs.rs/titlecase"
 repository = "https://github.com/wezm/titlecase"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See the [crate documentation][crate-docs].
 
 ## Building
 
-**Minimum Supported Rust Version:** 1.40.0
+**Minimum Supported Rust Version:** 1.70.0
 
 If you have a stable Rust compiler toolchain installed you can install
 the most recently released `titlecase` with cargo:


### PR DESCRIPTION
It's time to raise the minimum version of Rust to `1.70` and update the edition to `2021`. This is first of all for consistency, and secondly in this version you can use `std::sync::OnceLock`. Among other things, the minimum version is now checked by cargo itself due to the `rust-version` field in `Cargo.toml`. 